### PR TITLE
管理権限ユーザーでログインできるように

### DIFF
--- a/backend/app/controllers/api/admins_controller.rb
+++ b/backend/app/controllers/api/admins_controller.rb
@@ -1,0 +1,22 @@
+class Api::AdminsController < ApplicationController
+  def login
+    admin = Admin.find_by(email: params[:email])
+    if admin&.authenticate(params[:password])
+      token = JsonWebToken.encode(admin_id: admin.id)
+      render json: { token: token }, status: :ok
+    else
+      render json: { error: 'Invalid credentials' }, status: :unauthorized
+    end
+  end
+
+  def show
+    token = request.headers['Authorization']&.split(' ')&.last
+    decoded_token = JsonWebToken.decode(token)
+
+    if decoded_token && (admin = Admin.find_by(id: decoded_token[:admin_id]))
+      render json: { email: admin.email }, status: :ok
+    else
+      render json: { error: 'Unauthorized' }, status: :unauthorized
+    end
+  end
+end

--- a/backend/app/helpers/api/admins_helper.rb
+++ b/backend/app/helpers/api/admins_helper.rb
@@ -1,0 +1,2 @@
+module Api::AdminsHelper
+end

--- a/backend/app/models/admin.rb
+++ b/backend/app/models/admin.rb
@@ -1,0 +1,4 @@
+# app/models/admin.rb
+class Admin < ApplicationRecord
+  has_secure_password
+end

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -25,7 +25,7 @@ module Backend
     config.active_job.queue_adapter = :sidekiq
     config.middleware.use ActionDispatch::Cookies
     config.middleware.use ActionDispatch::Session::CookieStore, key: '_your_app_session'
-
+    config.autoload_paths << Rails.root.join('lib')
     config.autoload_paths += %W(#{config.root}/app/queries)
     config.eager_load_paths += %W(#{config.root}/app/queries)
   end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -9,10 +9,13 @@ Rails.application.routes.draw do
       resources :discussion_threads_week_populartopic, only: [:index]
       resources :discussion_threads_newtopic, only: [:index]
       resources :discussion_threads_recommendtopic, only: [:index]
+
       resources :posts, only: [:index, :show, :create], defaults: { format: :json } do
         resources :votes, only: [:create]
         resources :votes_status, only: [:index]
       end
     end
+    post "/login", to: "admins#login"
+    get "/admin", to: "admins#show"
   end
 end

--- a/backend/db/migrate/20250320052543_create_admins.rb
+++ b/backend/db/migrate/20250320052543_create_admins.rb
@@ -1,0 +1,10 @@
+class CreateAdmins < ActiveRecord::Migration[7.1]
+  def change
+    create_table :admins do |t|
+      t.string :email
+      t.string :password_digest
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -1,6 +1,25 @@
-ActiveRecord::Schema[7.1].define(version: 2025_03_19_153614) do
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.1].define(version: 2025_03_20_052543) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "admins", force: :cascade do |t|
+    t.string "email"
+    t.string "password_digest"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "discussion_threads", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "thread_title", null: false

--- a/backend/lib/json_web_token.rb
+++ b/backend/lib/json_web_token.rb
@@ -1,0 +1,18 @@
+# app/lib/json_web_token.rb
+require 'jwt'
+
+class JsonWebToken
+  SECRET_KEY = Rails.application.secrets.secret_key_base || "your_secret_key"
+
+  def self.encode(payload, exp = 24.hours.from_now)
+    payload[:exp] = exp.to_i
+    JWT.encode(payload, SECRET_KEY)
+  end
+
+  def self.decode(token)
+    decoded = JWT.decode(token, SECRET_KEY)[0]
+    HashWithIndifferentAccess.new(decoded)
+  rescue
+    nil
+  end
+end

--- a/backend/spec/helpers/api/admins_helper_spec.rb
+++ b/backend/spec/helpers/api/admins_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the Api::AdminsHelper. For example:
+#
+# describe Api::AdminsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe Api::AdminsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/backend/spec/models/admin_spec.rb
+++ b/backend/spec/models/admin_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Admin, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/backend/spec/requests/api/admins_spec.rb
+++ b/backend/spec/requests/api/admins_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Api::Admins", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/frontend/.env
+++ b/frontend/.env
@@ -5,3 +5,4 @@ VITE_DISCUSSION_THREAD_POPULAR_API_URL="http://localhost:3000/api/v1/discussion_
 VITE_DISCUSSION_THREAD_RECENT_API_URL="http://localhost:3000/api/v1/discussion_threads_newtopic"
 VITE_DISCUSSION_THREAD_RECOMMEND_API_URL="http://localhost:3000/api/v1/discussion_threads_recommendtopic"
 VITE_POSTS_API_URL="http://localhost:3000/api/v1/posts"
+VITE_LOGIN_API_URL="http://localhost:3000/api/login"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,12 +2,14 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Home from "./pages/Home";
 import MakeTopic from "./pages/MakeTopic";
 import ThreadPage from "./pages/ThreadPage";
+import Login from "./pages/admin/Admin";
 
 function App() {
   return (
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Home />} />
+        <Route path="/admin" element={<Login />} />
         <Route path="/make_topic" element={<MakeTopic />} />
         <Route path="threads/:id" element={<ThreadPage />} />
       </Routes>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import Home from "./pages/Home";
 import MakeTopic from "./pages/MakeTopic";
 import ThreadPage from "./pages/ThreadPage";
 import Login from "./pages/admin/Admin";
+import Dashboard from "./pages/admin/dashbord/Dashboard";
 
 function App() {
   return (
@@ -10,6 +11,7 @@ function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/admin" element={<Login />} />
+        <Route path="/dashboard" element={<Dashboard />} />
         <Route path="/make_topic" element={<MakeTopic />} />
         <Route path="threads/:id" element={<ThreadPage />} />
       </Routes>

--- a/frontend/src/components/Admin/Dashboard/Dashboard.tsx
+++ b/frontend/src/components/Admin/Dashboard/Dashboard.tsx
@@ -1,0 +1,23 @@
+import axios from "axios";
+import { useState } from "react";
+import { LOGIN_API_URL } from "../../../config";
+import { useNavigate } from "react-router-dom";
+import styles from "./dashboard.module.css";
+
+const Dashbord = () => {
+    const [email, setEmail] = useState("");
+    const [password, setPassword] = useState("");
+    const [error, setError] = useState("");
+    const navigate = useNavigate();
+
+    const handleLogin = async (e: React.FormEvent) => {
+    };
+
+    return (
+        <div className={styles.container}>
+            <h2 className={styles.loginTitle}>Dashbord</h2>
+        </div>
+    );
+};
+
+export default Dashbord;

--- a/frontend/src/components/Admin/Dashboard/dashboard.module.css
+++ b/frontend/src/components/Admin/Dashboard/dashboard.module.css
@@ -1,0 +1,60 @@
+html,
+body {
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: #c3e6fa;
+}
+
+.container {
+    padding: 20px;
+    margin-left: 40%;
+    background: rgb(159, 235, 159);
+    border-radius: 8px;
+    box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.1);
+    text-align: center;
+    width: 200px;
+    display: flex;
+    flex-direction: column;
+}
+
+.loginTitle {
+    font-size: 20px;
+    font-weight: bold;
+    margin-bottom: 20px;
+}
+
+form {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+}
+
+input {
+    margin-bottom: 10px;
+    padding: 10px;
+    width: 90%;
+    border: none;
+    border-radius: 5px;
+    background-color: white;
+}
+
+button {
+    margin-top: 10px;
+    padding: 10px;
+    width: 90%;
+    background-color: #ffcc00;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 16px;
+    color: black;
+}
+
+button:hover {
+    background-color: #e6b800;
+}

--- a/frontend/src/components/Admin/login/LoginForm.tsx
+++ b/frontend/src/components/Admin/login/LoginForm.tsx
@@ -1,7 +1,6 @@
-// src/components/LoginForm.jsx
+import axios from "axios";
 import { useState } from "react";
-// import { login } from "../api";
-// import { saveToken } from "../auth";
+import { LOGIN_API_URL } from "../../../config"; // APIのURLを統一
 import { useNavigate } from "react-router-dom";
 import styles from "./loginForm.module.css";
 
@@ -11,17 +10,16 @@ const LoginForm = () => {
     const [error, setError] = useState("");
     const navigate = useNavigate();
 
-    const handleLogin = async (e: { preventDefault: () => void; }) => {
+    const handleLogin = async (e: React.FormEvent) => {
         e.preventDefault();
-        setError("");
-
-        // try {
-        //     const { token } = await login(email, password);
-        //     saveToken(token);
-        //     navigate("/dashboard");
-        // } catch (err) {
-        //     setError("ログインに失敗しました。");
-        // }
+        try {
+            const response = await axios.post(`${LOGIN_API_URL}`, { email, password });
+            localStorage.setItem("token", response.data.token);
+            navigate("/dashboard");
+        } catch (err) {
+            setError("ログインに失敗しました。");
+            console.error(err);
+        }
     };
 
     return (

--- a/frontend/src/components/Admin/login/LoginForm.tsx
+++ b/frontend/src/components/Admin/login/LoginForm.tsx
@@ -1,0 +1,40 @@
+// src/components/LoginForm.jsx
+import { useState } from "react";
+// import { login } from "../api";
+// import { saveToken } from "../auth";
+import { useNavigate } from "react-router-dom";
+import styles from "./loginForm.module.css";
+
+const LoginForm = () => {
+    const [email, setEmail] = useState("");
+    const [password, setPassword] = useState("");
+    const [error, setError] = useState("");
+    const navigate = useNavigate();
+
+    const handleLogin = async (e: { preventDefault: () => void; }) => {
+        e.preventDefault();
+        setError("");
+
+        // try {
+        //     const { token } = await login(email, password);
+        //     saveToken(token);
+        //     navigate("/dashboard");
+        // } catch (err) {
+        //     setError("ログインに失敗しました。");
+        // }
+    };
+
+    return (
+        <div className={styles.container}>
+            <h2 className={styles.loginTitle}>管理者ログイン</h2>
+            {error && <p style={{ color: "red" }}>{error}</p>}
+            <form onSubmit={handleLogin}>
+                <input type="email" placeholder="メール" value={email} onChange={(e) => setEmail(e.target.value)} required />
+                <input type="password" placeholder="パスワード" value={password} onChange={(e) => setPassword(e.target.value)} required />
+                <button type="submit">ログイン</button>
+            </form>
+        </div>
+    );
+};
+
+export default LoginForm;

--- a/frontend/src/components/Admin/login/loginForm.module.css
+++ b/frontend/src/components/Admin/login/loginForm.module.css
@@ -1,0 +1,60 @@
+html,
+body {
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: #c7e9fc;
+}
+
+.container {
+    padding: 20px;
+    margin-left: 40%;
+    background: rgb(159, 235, 159);
+    border-radius: 8px;
+    box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.1);
+    text-align: center;
+    width: 200px;
+    display: flex;
+    flex-direction: column;
+}
+
+.loginTitle {
+    font-size: 20px;
+    font-weight: bold;
+    margin-bottom: 20px;
+}
+
+form {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+}
+
+input {
+    margin-bottom: 10px;
+    padding: 10px;
+    width: 90%;
+    border: none;
+    border-radius: 5px;
+    background-color: white;
+}
+
+button {
+    margin-top: 10px;
+    padding: 10px;
+    width: 90%;
+    background-color: #ffcc00;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 16px;
+    color: black;
+}
+
+button:hover {
+    background-color: #e6b800;
+}

--- a/frontend/src/components/Home/contents/subTopic/recommendTopic/RecommendTopic.tsx
+++ b/frontend/src/components/Home/contents/subTopic/recommendTopic/RecommendTopic.tsx
@@ -4,8 +4,8 @@ import { DISCUSSION_RECOMMEND_API_URL } from "../../../../../config";
 import styles from "./recommendTopic.module.css";
 import { Link } from "react-router-dom";
 
-const WeekPopularTopic = () => {
-    const [weekPopularThreads, setweekPopularThreads] = useState<
+const recommendTopic = () => {
+    const [recommendThreads, setrecommendThreads] = useState<
         { thread_title: string; id: string; created_at: string; comments_count: number }[]
     >([]);
 
@@ -13,8 +13,7 @@ const WeekPopularTopic = () => {
         const fetchThreadsTitle = async () => {
             try {
                 const response = await axios.get(DISCUSSION_RECOMMEND_API_URL, {});
-                console.log(response.data.data);
-                setweekPopularThreads(response.data.data);
+                setrecommendThreads(response.data.data);
             } catch (err) {
                 console.log(err);
             }
@@ -24,8 +23,8 @@ const WeekPopularTopic = () => {
 
     return (
         <>
-            {weekPopularThreads.length > 0 ? (
-                weekPopularThreads.map((thread, index) => (
+            {recommendThreads.length > 0 ? (
+                recommendThreads.map((thread, index) => (
                     <div key={index}>
                         <Link key={thread.id} to={`threads/${thread.id}`} state={thread}>
                             <div className={styles.threadConfig}>
@@ -48,4 +47,4 @@ const WeekPopularTopic = () => {
     );
 };
 
-export default WeekPopularTopic;
+export default recommendTopic;

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -8,3 +8,4 @@ export const DISCUSSION_THREAD_RECENT_API_URL = import.meta.env
 export const DISCUSSION_RECOMMEND_API_URL = import.meta.env
   .VITE_DISCUSSION_THREAD_RECOMMEND_API_URL;
 export const POSTS_API_URL = import.meta.env.VITE_POSTS_API_URL;
+export const LOGIN_API_URL = import.meta.env.VITE_LOGIN_API_URL;

--- a/frontend/src/pages/admin/Admin.tsx
+++ b/frontend/src/pages/admin/Admin.tsx
@@ -1,0 +1,11 @@
+import styles from "./admin.module.css";
+import Login from "../../components/Admin/login/LoginForm";
+const Admin = () => {
+    return (
+        <div className={styles.body}>
+            <Login />
+        </div>
+    );
+};
+
+export default Admin;

--- a/frontend/src/pages/admin/admin.module.css
+++ b/frontend/src/pages/admin/admin.module.css
@@ -1,0 +1,16 @@
+* {
+    margin: 0;
+    padding: 0;
+}
+
+.body {
+    display: flex;
+    /* align-items: flex-start; */
+    flex-direction: column;
+    margin: 0;
+}
+
+.contents {
+    margin: 0 auto;
+    width: 1040px;
+}

--- a/frontend/src/pages/admin/dashbord/Dashboard.tsx
+++ b/frontend/src/pages/admin/dashbord/Dashboard.tsx
@@ -1,0 +1,12 @@
+import styles from "./dashboard.module.css";
+import Dashbord from "../../../components/Admin/Dashboard/Dashboard";
+
+const Dashboard = () => {
+    return (
+        <div className={styles.body}>
+            <Dashbord />
+        </div>
+    );
+};
+
+export default Dashboard;

--- a/frontend/src/pages/admin/dashbord/dashboard.module.css
+++ b/frontend/src/pages/admin/dashbord/dashboard.module.css
@@ -1,0 +1,16 @@
+* {
+    margin: 0;
+    padding: 0;
+}
+
+.body {
+    display: flex;
+    /* align-items: flex-start; */
+    flex-direction: column;
+    margin: 0;
+}
+
+.contents {
+    margin: 0 auto;
+    width: 1040px;
+}


### PR DESCRIPTION
JWT認証を採用。
dbにあるadminsテーブルに登録されているメール、パスワードが一致したら、トークンを返し、24時間自分のフロントのほうでトークンを保存しておく、それがあれば、dashbord（管理者専用ページ)にログイン可能。

dbに独立したadminsテーブルを追加。

そもそもadminsテーブルに管理者権限を追加する方法をどうするか...。
今のところは、dbeaverから手動で追加。