### PR TITLE
報告機能追加

### DIFF
--- a/backend/app/controllers/api/v1/report/posts_report_controller.rb
+++ b/backend/app/controllers/api/v1/report/posts_report_controller.rb
@@ -1,0 +1,21 @@
+module Api
+  module V1
+    module Report
+      class PostsReportController < ApplicationController
+        def create
+          report = ::Report.create_by_params(report_params)
+
+          render json: { message: "通報を受け付けました" }, status: :created
+        rescue ActiveRecord::RecordInvalid => e
+          render json: { error: e.record.errors.full_messages }, status: :unprocessable_entity
+        end
+
+        private
+
+        def report_params
+          params.require(:report).permit(:post_id, :reason_code, :comment)
+        end
+      end
+    end
+  end
+end

--- a/backend/app/models/report.rb
+++ b/backend/app/models/report.rb
@@ -1,0 +1,13 @@
+class Report < ApplicationRecord
+  belongs_to :post
+
+  VALID_REASON_CODES = %w[SPAM ABUSE MISINFORMATION INAPPROPRIATE OTHER].freeze
+
+  validates :reason_code, presence: true, inclusion: { in: VALID_REASON_CODES }
+
+  def self.create_by_params(params)
+    report = new(params)
+    report.save!
+    report
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -16,6 +16,9 @@ Rails.application.routes.draw do
         resources :votes, only: [:create]
         resources :votes_status, only: [:index]
       end
+      namespace :report do
+        resources :posts_report, only: [:create]
+      end
 
       namespace :admin do
         resources :discussion_threads_admin_topic, only: [:index, :destroy, :update]

--- a/backend/db/migrate/20250321140310_create_reports.rb
+++ b/backend/db/migrate/20250321140310_create_reports.rb
@@ -1,0 +1,11 @@
+class CreateReports < ActiveRecord::Migration[7.0]
+  def change
+    create_table :reports, id: :uuid do |t|
+      t.references :post, null: false, foreign_key: true, type: :uuid
+      t.references :user, null: false, foreign_key: true, type: :uuid
+      t.string :reason_code, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/migrate/20250321153152_update_reports_add_comment_and_remove_user_id.rb
+++ b/backend/db/migrate/20250321153152_update_reports_add_comment_and_remove_user_id.rb
@@ -1,0 +1,9 @@
+class UpdateReportsAddCommentAndRemoveUserId < ActiveRecord::Migration[7.0]
+  def change
+    add_column :reports, :comment, :text
+
+    remove_foreign_key :reports, :users
+
+    remove_reference :reports, :user, type: :uuid, index: true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_20_143432) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_21_153152) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -44,6 +44,15 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_20_143432) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "reports", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "post_id", null: false
+    t.string "reason_code", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "comment"
+    t.index ["post_id"], name: "index_reports_on_post_id"
+  end
+
   create_table "thread_stats", primary_key: "discussion_thread_id", id: :uuid, default: nil, force: :cascade do |t|
     t.integer "total_likes_m", default: 0, null: false
     t.integer "total_likes_f", default: 0, null: false
@@ -71,6 +80,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_20_143432) do
   add_foreign_key "posts", "discussion_threads"
   add_foreign_key "posts", "users"
   add_foreign_key "recommended_threads", "discussion_threads", on_delete: :cascade
+  add_foreign_key "reports", "posts"
   add_foreign_key "thread_stats", "discussion_threads", on_delete: :cascade
   add_foreign_key "votes", "posts"
   add_foreign_key "votes", "users"

--- a/frontend/.env
+++ b/frontend/.env
@@ -8,6 +8,7 @@ VITE_DISCUSSION_THREAD_ADMIN_API_URL="http://localhost:3000/api/v1/admin/discuss
 VITE_DISCUSSION_THREAD_ADMIN_RECOMMENDED_API_URL="http://localhost:3000/api/v1/admin/discussion_threads_admin_recommended_topic"
 VITE_DISCUSSION_THREAD_ADMIN_POSTS_API_URL="http://localhost:3000/api/v1/admin/discussion_threads_admin_posts"
 VITE_POSTS_API_URL="http://localhost:3000/api/v1/posts"
+VITE_POST_REPORT_API_URL="http://localhost:3000/api/v1/report/posts_report"
 VITE_POSTS_API_URL="http://localhost:3000/api/v1/posts"
 VITE_LOGIN_ADMIN_USER_API_URL="http://localhost:3000/api/v1/admin"
 VITE_LOGIN_API_URL="http://localhost:3000/api/v1/login"

--- a/frontend/src/components/ThreadPage/threadDetail/postDetail/PostDetail.tsx
+++ b/frontend/src/components/ThreadPage/threadDetail/postDetail/PostDetail.tsx
@@ -4,6 +4,7 @@ import { POSTS_API_URL } from "../../../../config";
 import styles from "./postDetail.module.css";
 import YYDDMM from "../YYDDMM/YYDDMM";
 import VoteBar from "./VoteBar/VoteBar";
+import PostMenu from "./postMenu/PostMenu";
 interface Posts {
   id: string;
   disscussion_thread_id: string;
@@ -41,6 +42,7 @@ const PostDetail = (porps: Props) => {
             <div>{index + 1}.&nbsp;</div>
             <div>匿名:&nbsp;{post.gender == 1 ? "男" : "女"}&nbsp;</div>
             <YYDDMM dateInfo={new Date(post.created_at)} />
+            <PostMenu postId={post.id} />
           </div>
           <p>{post.content}</p>
           <VoteBar post_id={post.id} />

--- a/frontend/src/components/ThreadPage/threadDetail/postDetail/postMenu/PostMenu.tsx
+++ b/frontend/src/components/ThreadPage/threadDetail/postDetail/postMenu/PostMenu.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useRef, useState } from "react";
+import styles from "./postMenu.module.css";
+import ReportModal from "../postMenu/reportModal/ReportModal";
+import { useReport } from "../../../../../hook/report/useReport";
+import { ReportReasonCode } from "../../../../../constants/reportReasons";
+interface Props {
+    postId: string;
+}
+
+const PostMenu = ({ postId }: Props) => {
+    const [open, setOpen] = useState(false);
+    const [showModal, setShowModal] = useState(false);
+    const menuRef = useRef<HTMLDivElement>(null);
+
+    const { handleReportSubmit } = useReport();
+
+    const handleSubmit = async (reasonCode: ReportReasonCode, comment?: string) => {
+        await handleReportSubmit(postId, reasonCode, comment);
+        setShowModal(false);
+    };
+
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+                setOpen(false);
+            }
+        };
+
+        if (open) {
+            document.addEventListener("mousedown", handleClickOutside);
+        }
+
+        return () => {
+            document.removeEventListener("mousedown", handleClickOutside);
+        };
+    }, [open]);
+
+    return (
+        <div className={styles.menuContainer} ref={menuRef}>
+            <button className={styles.menuButton} onClick={() => setOpen(!open)}>︙</button>
+            {open && (
+                <div className={styles.dropdown}>
+                    <button
+                        className={styles.reportButton}
+                        onClick={() => setShowModal(true)}
+                    >
+                        🚨 通報する
+                    </button>
+                </div>
+            )}
+            {showModal && (
+                <ReportModal
+                    onClose={() => setShowModal(false)}
+                    onSubmit={handleSubmit}
+                />
+            )}
+        </div>
+    );
+};
+
+export default PostMenu;

--- a/frontend/src/components/ThreadPage/threadDetail/postDetail/postMenu/postMenu.module.css
+++ b/frontend/src/components/ThreadPage/threadDetail/postDetail/postMenu/postMenu.module.css
@@ -1,0 +1,32 @@
+.menuContainer {
+    position: relative;
+    margin-left: auto;
+}
+
+.menuButton {
+    background: none;
+    border: none;
+    font-size: 20px;
+    cursor: pointer;
+}
+
+.dropdown {
+    position: absolute;
+    top: 20px;
+    width: 100px;
+    right: 0;
+    background: white;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    z-index: 10;
+    padding: 5px 10px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+
+.reportButton {
+    background: none;
+    border: none;
+    color: red;
+    cursor: pointer;
+    font-size: 14px;
+}

--- a/frontend/src/components/ThreadPage/threadDetail/postDetail/postMenu/reportModal/ReportModal.tsx
+++ b/frontend/src/components/ThreadPage/threadDetail/postDetail/postMenu/reportModal/ReportModal.tsx
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import styles from "./reportModal.module.css";
+import { REPORT_REASON_OPTIONS, ReportReasonCode } from "../../../../../../constants/reportReasons";
+import { Props } from "../../../../../../types/menu";
+
+
+const ReportModal = ({ onClose, onSubmit }: Props) => {
+    const [selectedReason, setSelectedReason] = useState<ReportReasonCode | "">("");
+    const [comment, setComment] = useState("");
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!selectedReason) {
+            alert("通報理由を選択してください");
+            return;
+        }
+        if (selectedReason === "OTHER" && !comment.trim()) {
+            alert("詳細を入力してください");
+            return;
+        }
+        if (comment.length > 200) {
+            alert("コメントは200文字以内で入力してください");
+            return;
+        }
+        onSubmit(selectedReason, comment.trim() || undefined);
+        onClose();
+    };
+
+    return (
+        <div className={styles.overlay}>
+            <div className={styles.modal}>
+                <h3>この投稿を通報する</h3>
+                <form onSubmit={handleSubmit}>
+                    <div className={styles.radioGroup}>
+                        {Object.entries(REPORT_REASON_OPTIONS).map(([code, label]) => (
+                            <label key={code} className={styles.radioWrapper}>
+                                <input
+                                    type="radio"
+                                    name="reason"
+                                    value={code}
+                                    checked={selectedReason === code}
+                                    onChange={() => setSelectedReason(code as ReportReasonCode)}
+                                    className={styles.radioInput}
+                                />
+                                <span className={styles.customRadio} />
+                                <span className={styles.radioLabel}>{label}</span>
+                            </label>
+                        ))}
+                    </div>
+
+                    <textarea
+                        className={styles.commentInput}
+                        placeholder={
+                            selectedReason === "OTHER"
+                                ? "詳細を入力（200文字以内）*必須"
+                                : "詳細を入力（200文字以内）"
+                        }
+                        maxLength={200}
+                        value={comment}
+                        onChange={(e) => setComment(e.target.value)}
+                    />
+
+                    <div className={styles.actions}>
+                        <button type="submit">通報する</button>
+                        <button type="button" onClick={onClose}>キャンセル</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    );
+};
+
+export default ReportModal;

--- a/frontend/src/components/ThreadPage/threadDetail/postDetail/postMenu/reportModal/reportModal.module.css
+++ b/frontend/src/components/ThreadPage/threadDetail/postDetail/postMenu/reportModal/reportModal.module.css
@@ -1,0 +1,95 @@
+.overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+    backdrop-filter: blur(3px);
+    /* 背景ぼかし */
+}
+
+.modal {
+    background: #fff;
+    padding: 24px;
+    border-radius: 16px;
+    width: 90%;
+    max-width: 460px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+    animation: fadeIn 0.3s ease-in-out;
+    font-family: "Segoe UI", sans-serif;
+}
+
+.actions {
+    margin-top: 10px;
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+}
+
+.commentInput {
+    width: 100%;
+    resize: none;
+    height: 100px;
+}
+
+.radioGroup {
+    margin-top: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 12px;
+}
+
+.radioItem {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 15px;
+}
+
+.radioWrapper {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 10px;
+    cursor: pointer;
+    user-select: none;
+    position: relative;
+}
+
+.radioInput {
+    display: none;
+}
+
+.customRadio {
+    width: 18px;
+    height: 18px;
+    border: 2px solid #444;
+    border-radius: 50%;
+    position: relative;
+    transition: border-color 0.3s;
+}
+
+.radioInput:checked+.customRadio {
+    border-color: #007bff;
+}
+
+.radioInput:checked+.customRadio::after {
+    content: "";
+    position: absolute;
+    top: 5px;
+    left: 5px;
+    width: 8px;
+    height: 8px;
+    background-color: #007bff;
+    border-radius: 50%;
+}
+
+.radioLabel {
+    font-size: 15px;
+}

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -16,3 +16,4 @@ export const DISCUSSION_THREAD_ADMIN_POSTS_API_URL = import.meta.env
 export const POSTS_API_URL = import.meta.env.VITE_POSTS_API_URL;
 export const LOGIN_API_URL = import.meta.env.VITE_LOGIN_API_URL;
 export const LOGIN_ADMIN_USER_API_URL = import.meta.env.VITE_LOGIN_ADMIN_USER_API_URL;
+export const POSTS_REPORT_API_URL = import.meta.env.VITE_POST_REPORT_API_URL;

--- a/frontend/src/constants/reportReasons.ts
+++ b/frontend/src/constants/reportReasons.ts
@@ -1,0 +1,9 @@
+export const REPORT_REASON_OPTIONS = {
+    SPAM: "スパム・宣伝目的",
+    ABUSE: "暴言や差別的な表現",
+    MISINFORMATION: "誤情報・虚偽の内容",
+    INAPPROPRIATE: "不適切な内容",
+    OTHER: "その他"
+} as const;
+
+export type ReportReasonCode = keyof typeof REPORT_REASON_OPTIONS;

--- a/frontend/src/hook/report/useReport.ts
+++ b/frontend/src/hook/report/useReport.ts
@@ -1,0 +1,19 @@
+import axios from "axios";
+import { REPORT_REASON_OPTIONS, ReportReasonCode } from "../../constants/reportReasons";
+import { POSTS_REPORT_API_URL } from "../../config";
+
+export const useReport = () => {
+    const handleReportSubmit = async (postId: string, reasonCode: ReportReasonCode, comment?: string) => {
+        await axios.post(POSTS_REPORT_API_URL, {
+            report: {
+                post_id: postId,
+                reason_code: reasonCode,
+                comment: comment || null,
+            }
+        });
+
+        alert(`通報しました（理由: ${REPORT_REASON_OPTIONS[reasonCode]}${comment ? ` / 詳細: ${comment}` : ""}）`);
+    };
+
+    return { handleReportSubmit };
+};

--- a/frontend/src/types/menu.ts
+++ b/frontend/src/types/menu.ts
@@ -1,0 +1,6 @@
+import { ReportReasonCode } from "../constants/reportReasons";
+
+export interface Props {
+    onClose: () => void;
+    onSubmit: (reasonCode: ReportReasonCode, comment?: string) => void;
+}


### PR DESCRIPTION
フロント側にtypesフォルダを実装。
ここにinterface系を書きます。

フロント側にconstantsフォルダを実装。
ここに共通するconstを書きます。

export const REPORT_REASON_OPTIONS = {
    SPAM: "スパム・宣伝目的",
    ABUSE: "暴言や差別的な表現",
    MISINFORMATION: "誤情報・虚偽の内容",
    INAPPROPRIATE: "不適切な内容",
    OTHER: "その他"
} as const;
こういったやつ

新たにpostを継承したreportテーブルを追加

![スクリーンショット 2025-03-22 010127](https://github.com/user-attachments/assets/9bb39365-df83-4a4e-9338-b4ef0557c001)


![スクリーンショット 2025-03-22 005100](https://github.com/user-attachments/assets/1e2befc2-a206-48e9-9c96-af7bb9d60703)
![スクリーンショット 2025-03-22 005110](https://github.com/user-attachments/assets/b513b313-e2f9-4648-9b5f-02cf73200574)
